### PR TITLE
Implementing an asynchronous client on top of the existing one

### DIFF
--- a/src/main/java/com/github/tasubo/jgmp/AsyncMpClient.java
+++ b/src/main/java/com/github/tasubo/jgmp/AsyncMpClient.java
@@ -1,0 +1,57 @@
+package com.github.tasubo.jgmp;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class AsyncMpClient {
+
+	private final ExecutorService executorService;
+
+	private final MpClient client;
+
+	public AsyncMpClient(MpClient client, int concurrentRequests) {
+		this.client = client;
+		this.executorService = Executors.newFixedThreadPool(concurrentRequests);
+	}
+
+	public void send(Sendable sendable) {
+		SenderJob job = new SenderJob(sendable, client);
+
+		executorService.submit(job);
+	}
+	
+	public void shutdown() {
+		
+		executorService.shutdownNow();
+	}
+
+	static final class SenderJob implements Runnable {
+
+		private static final Logger LOGGER = Logger.getLogger(SenderJob.class.getCanonicalName());
+
+		private final Sendable sendable;
+
+		private MpClient mpClient;
+
+		public SenderJob(Sendable sendable, MpClient mpClient) {
+			this.sendable = sendable;
+			this.mpClient = mpClient;
+		}
+
+		@Override
+		public void run() {
+
+			try {
+
+				this.mpClient.send(sendable);
+			} catch (Exception e) {
+
+				if (LOGGER.isLoggable(Level.SEVERE)) {
+					LOGGER.log(Level.SEVERE, "Caught exception while asynchronously sending request", e);
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/github/tasubo/jgmp/MpClient.java
+++ b/src/main/java/com/github/tasubo/jgmp/MpClient.java
@@ -95,6 +95,11 @@ public final class MpClient {
             MpClient client = new MpClient(this);
             return client;
         }
+		
+		public AsyncMpClient createAsyncClient(int concurrentRequests) {
+			AsyncMpClient client = new AsyncMpClient(create(), concurrentRequests);
+			return client;
+		}
 
         public MpClientBuilder using(Decorating decorating) {
             AppendingDecorator localDecorator = new AppendingDecorator(appendingDecorator, decorating);
@@ -219,4 +224,5 @@ public final class MpClient {
             return text;
         }
     }
+	
 }

--- a/src/test/java/com/github/tasubo/jgmp/AsyncRequestTest.java
+++ b/src/test/java/com/github/tasubo/jgmp/AsyncRequestTest.java
@@ -1,0 +1,52 @@
+package com.github.tasubo.jgmp;
+
+import org.junit.Test;
+
+import static com.github.tasubo.jgmp.Mocks.*;
+import static com.github.tasubo.jgmp.MpAssert.*;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+public class AsyncRequestTest {
+
+	@Before
+	public void clearRequestLog() {
+
+		getRequestLog().clear();
+	}
+
+	@Test
+	public void shouldNotBlockMainThread() throws InterruptedException {
+
+		/*
+		 * each http request takes 50 milliseconds
+		 */
+		AsyncMpClient client = MpClient.withTrackingId("UA-XXXX-Y")
+				.withClientId("35009a79-1a05-49d7-b876-2b884d0f825b")
+				.httpRequester(new SlowMockHttpRequester())
+				.createAsyncClient(10);
+
+		long startTime = System.currentTimeMillis();
+
+		for (int i = 0; i < 10; i++) {
+
+			Social social = Social.fromNetwork("facebook")
+					.action("like")
+					.target("http://foo.com");
+
+			client.send(social);
+		}
+
+		long endTime = System.currentTimeMillis();
+		long mainThreadDuration = endTime - startTime;
+
+		/*
+		 * giving worker threads time to complete so we can check
+		 * if requests were performed
+		 */
+		Thread.sleep(60);
+
+		assertTrue("main thread was blocked for more than 10 milliseconds, but requests should have been executed asynchronously", mainThreadDuration <= 10);
+		assertEquals(10, getRequestLog().size());
+	}
+}

--- a/src/test/java/com/github/tasubo/jgmp/Mocks.java
+++ b/src/test/java/com/github/tasubo/jgmp/Mocks.java
@@ -1,11 +1,12 @@
 package com.github.tasubo.jgmp;
 
 import java.util.*;
+import java.util.concurrent.LinkedBlockingDeque;
 
 public class Mocks {
 
     private static final HttpRequester REQUESTER = new MockHttpRequester();
-    private static final Deque<String> REQUESTS = new ArrayDeque<String>();
+    private static final Deque<String> REQUESTS = new LinkedBlockingDeque<String>();
 
     public static SystemInfo prepareSystemInfo() {
         return SystemInfo.with().javaEnabled().viewport(800, 600).create();
@@ -51,6 +52,32 @@ public class Mocks {
             REQUESTS.add(url);
         }
     }
+	
+	public static class SlowMockHttpRequester implements HttpRequester {
+		        
+		@Override
+        public void sendGet(String host, String payload) {
+			sleepQuietly(50);
+			
+            String url = host + "?" + payload;
+            REQUESTS.add(url);
+        }
+
+        @Override
+        public void sendPost(String host, String payload) {
+			sleepQuietly(50);
+            String url = host + "?" + payload;
+            REQUESTS.add(url);
+        }
+
+		private void sleepQuietly(long sleepMillis) {
+			try {
+				Thread.sleep(sleepMillis);
+			} catch (InterruptedException ex) {
+				
+			}
+		}
+	}
 
     public static class RequestLog {
         public String last() {
@@ -71,5 +98,9 @@ public class Mocks {
         public void clear() {
             REQUESTS.clear();
         }
+		
+		public int size() {
+			return REQUESTS.size();
+		}
     }
 }


### PR DESCRIPTION
Hi Tadas.

So I took some time this morning to implement asynchronous requests, including a test case.

I implemented this in a different class "AsyncMpClient", which uses an existing MpClient and just adds asynchronous functionality. It can be constructed using MpClientBuilder "createAsyncClient(int concurrentRequests)".
I did this in order not to break immutability of the original client. Well at least your test cases politely asked me not do it ;-)

The REQUESTS dequeue had to be changed to a thread safe implementation in order to support my test case. The count() addition to RequestLog is used to verify that all my ten test message have been sent.

I tried hard not to violate your design consideration; I probably failed anyway, so please let me know where you disagree :-)

Best regards

Marius
