### PR TITLE
Bugfix/async requester test timings

### DIFF
--- a/src/main/java/com/github/tasubo/jgmp/AsyncHttpRequester.java
+++ b/src/main/java/com/github/tasubo/jgmp/AsyncHttpRequester.java
@@ -2,6 +2,7 @@ package com.github.tasubo.jgmp;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -20,7 +21,13 @@ public final class AsyncHttpRequester implements HttpRequester {
 		this.executorService = Executors.newFixedThreadPool(concurrentRequests);
 	}
 	
-	public void shutdown() {
+	public void shutdownGracefully(long terminationTimeout) throws InterruptedException {
+		
+		executorService.shutdown();
+		executorService.awaitTermination(terminationTimeout, TimeUnit.MILLISECONDS);
+	}
+	
+	public void shutdownNow() {
 		
 		executorService.shutdownNow();
 	}

--- a/src/main/java/com/github/tasubo/jgmp/Event.java
+++ b/src/main/java/com/github/tasubo/jgmp/Event.java
@@ -7,27 +7,22 @@ public final class Event implements Sendable {
     private final Integer value;
     private final Parametizer parametizer;
 
-    private Event(String category, String label, String action) {
-        this.action = action;
-        this.label = label;
-        this.category = category;
-        this.value = null;
-        parametizer = new Parametizer("t", "event", "ec", this.category, "ea", this.action, "el", this.label, "ev", value);
-    }
-
-    private Event(String category, String label, String action, int value) {
-        this.category = category;
-        this.label = label;
-        this.action = action;
-        this.value = value;
-        parametizer = new Parametizer("t", "event", "ec", this.category, "ea", this.action, "el", this.label, "ev", this.value);
-    }
-
-    public static EventBuilder of(String category, String label) {
+	
+	public static EventBuilderStart ofCategory(String category) {
+		
         Ensure.length(150, category);
-        Ensure.length(500, label);
-        return new EventBuilder(category, label);
-    }
+		return new EventBuilderStart(category);
+	}
+
+	private Event(EventBuilder eventBuilder) {
+		
+		this.action = eventBuilder.action;
+		this.category = eventBuilder.category;
+		this.label = eventBuilder.label;
+		this.value = eventBuilder.value;
+		
+        parametizer = new Parametizer("t", "event", "ec", this.category, "ea", this.action, "el", this.label, "ev", this.value);
+	}
 
     @Override
     public String getText() {
@@ -39,23 +34,44 @@ public final class Event implements Sendable {
         return new Combine(this).with(app);
     }
 
+	public static class EventBuilderStart {
+		
+		private final String category;
+		
+		private EventBuilderStart(String category) {
+			this.category = category;
+		}
+		
+		public EventBuilder withAction(String action) {
+			Ensure.length(500, action);
+			return new EventBuilder(category, action, null, null);
+		}
+	}
 
     public static class EventBuilder {
         private final String category;
         private final String label;
+		private final Integer value;
+		private final String action;
 
-        private EventBuilder(String category, String label) {
+        private EventBuilder(String category, String action, String label, Integer value) {
             this.category = category;
             this.label = label;
+			this.value = value;
+			this.action = action;
         }
 
-        public Event action(String action) {
-            Ensure.length(500, action);
-            return new Event(category, label, action);
-        }
+		public EventBuilder withValue(Integer value) {
+			return new EventBuilder(category, action, label, value);
+		}
+		
+		public EventBuilder labeled(String label) {
+			Ensure.length(500, label);
+			return new EventBuilder(category, action, label, value);
+		}
 
-        public Event action(String action, int value) {
-            return new Event(category, label, action, value);
-        }
-    }
+		public Event create() {
+			return new Event(this);
+		}
+	}
 }

--- a/src/test/java/com/github/tasubo/jgmp/EventTest.java
+++ b/src/test/java/com/github/tasubo/jgmp/EventTest.java
@@ -13,42 +13,51 @@ public class EventTest {
     public void shouldSendEvent() {
         MpClient mp = prepareMpClient();
 
-        mp.send(Event.of("Category", "Label").action("ButtonClick", 3));
+        mp.send(Event.ofCategory("Category").withAction("ButtonClick").labeled("Label").withValue(3).create());
 
         assertThat(getRequestLog().last(), hasParam("t").withValue("event"));
         assertThat(getRequestLog().last(), hasParam("tid").withValue("UA-XXXX-Y"));
         assertThat(getRequestLog().last(), hasParam("cid").withValue("35009a79-1a05-49d7-b876-2b884d0f825b"));
     }
+	
+    @Test
+    public void shouldSendEventWithoutLabel() {
+        MpClient mp = prepareMpClient();
 
+        mp.send(Event.ofCategory("Category").withAction("ButtonClick").withValue(3).create());
+
+		assertThat(getRequestLog().last(), hasNoParam("el"));
+		
+    }
 
     @Test
     public void shouldSendEventWithCorrectParameters() {
         MpClient mp = Mocks.prepareMpClient();
         assertThat(mp, notNullValue());
 
-        mp.send(Event.of("Category", "Label").action("ButtonClick"));
+        mp.send(Event.ofCategory("Category").withAction("ButtonClick").labeled("Label").create());
 
         assertThat(getRequestLog().last(), hasParam("ec").withValue("Category"));
         assertThat(getRequestLog().last(), hasParam("el").withValue("Label"));
         assertThat(getRequestLog().last(), hasParam("ea").withValue("ButtonClick"));
 
-        mp.send(Event.of("Category", "Label").action("ButtonClick", 3));
+        mp.send(Event.ofCategory("Category").withAction("ButtonClick").labeled("Label").withValue(3).create());
         assertThat(getRequestLog().last(), hasParam("ev").withValue("3"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldLimitActionLength() {
-        Event.of("Category", "Label").action(stringWithLength(501));
+		Event.ofCategory("Category").withAction(stringWithLength(501)).labeled("Label").create();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldLimitCategoryLength() {
-        Event.of(stringWithLength(151), "Label");
+        Event.ofCategory(stringWithLength(151)).withAction("ButtonClick").labeled("Label").withValue(3).create();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldLimitLabelLength() {
-        Event.of("Category", stringWithLength(501));
+        Event.ofCategory("Category").withAction("ButtonClick").labeled(stringWithLength(501)).withValue(3).create();
     }
 
 }

--- a/src/test/java/com/github/tasubo/jgmp/GoogleEndpointIntegrationTest.java
+++ b/src/test/java/com/github/tasubo/jgmp/GoogleEndpointIntegrationTest.java
@@ -47,7 +47,7 @@ public class GoogleEndpointIntegrationTest {
 
         App app = App.named("jGMP integration test").version("1.Z").create();
 
-        mpClient.send(Event.of("Test", "Integration").action("testhit").with(app));
+        mpClient.send(Event.ofCategory("Test").withAction("testhit").labeled("Integration").create().with(app));
     }
 
     @Test

--- a/src/test/java/com/github/tasubo/jgmp/Mocks.java
+++ b/src/test/java/com/github/tasubo/jgmp/Mocks.java
@@ -17,7 +17,7 @@ public class Mocks {
     }
 
     public static Sendable prepareSendable() {
-        return Event.of("Category", "Label").action("Action");
+        return Event.ofCategory("Category").withAction("Action").labeled("Label").create();
     }
 
     public static MpClient prepareMpClient() {

--- a/src/test/java/com/github/tasubo/jgmp/MpAssert.java
+++ b/src/test/java/com/github/tasubo/jgmp/MpAssert.java
@@ -13,6 +13,10 @@ public class MpAssert {
     public static HasParamMatcher hasParam(String v) {
         return new HasParamMatcher(v);
     }
+	
+    public static NoParamMatcher hasNoParam(String v) {
+        return new NoParamMatcher(v);
+    }
 
     static class HasParamMatcher extends BaseMatcher<String> {
 
@@ -41,6 +45,28 @@ public class MpAssert {
 
         public Matcher<? super String> withBareValue(String value) {
             return new HasParamValueMatcher(param, value, true);
+        }
+    }
+	
+	    static class NoParamMatcher extends BaseMatcher<String> {
+
+        private final String param;
+
+        public NoParamMatcher(String value) {
+            this.param = value;
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            if (param.equals("v")) {
+                return item.toString().indexOf("?v") == -1;
+            }
+            return item.toString().indexOf("&" + param) == -1;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("no parameter \"" + param + "\" present");
         }
     }
 


### PR DESCRIPTION
mhhh this pull contains a bit too much, since I based from the wrong commit :-/

Regarding the commit: I tried to make the test case for async http requester more resilient. Testing asynchronous stuff is really difficult; in my eyes the only way to do it reliably is mocking the executor service, injecting it into the class (I don't want to have this as part of the public api actually) and then checking that submit is called.
As this seems more error prone than the actual implementation (we would also have to consider thread-safety of the mocking framework), I chose a different approach.

However I implemented a soft shutdown of the async requester, so the test will finish as soon as all jobs are done. The test now has a hard timeout of 1 second, after which it will fail.
So it should still run fast, it tests the issue and it will detect if there is a problem.
